### PR TITLE
tzsp: remove "pad" tag; send as "received" packet

### DIFF
--- a/rsniffer.c
+++ b/rsniffer.c
@@ -30,8 +30,7 @@ struct  tzsp_hdr {
 	    uint8_t encapH;
 	    uint8_t encapL;
 
-	    uint8_t tagType;
-	    uint8_t tagLen;
+	    uint8_t tagEnd;
 	} tzspHdr;
 
 struct gre_hdr {
@@ -284,11 +283,10 @@ int main(int argc,char **argv) {
 	}
 
 	tzspHdr.version = 1;
-	tzspHdr.type = 1;
+	tzspHdr.type = 0;
 	tzspHdr.encapH = 0;
 	tzspHdr.encapL = 1;
-	tzspHdr.tagType = 0;
-	tzspHdr.tagLen = 1;
+	tzspHdr.tagEnd = 1;
 
 	txBuf = malloc(MAX_CAPTURE_BUFFER_SIZE + sizeof(tzspHdr));
 


### PR DESCRIPTION
A couple of small improvements to the tzsp encapsulation:

 - Send as a received packet, instead of a packet to be transmitted. The [description][] indicates the current encapsulation is requesting the encapsulated packet be retransmitted by the receiver.

 - Remove unnecessary "pad" tag. The "end" and "pad" tags do not contain a length value. Sending the bytes `[0, 1]` in the tag section means `[pad, end]`.

Wireshark decodes:

Before:
```
TZSP: Ethernet 
    Version: 1
    Type: Packet for transmit (1)
    Encapsulation: Ethernet (1)
    Pad
        Option Tag: Pad (0)
    End
        Option Tag: End (1)
```

After:
```
TZSP: Ethernet 
    Version: 1
    Type: Received packet (0)
    Encapsulation: Ethernet (1)
    End
        Option Tag: End (1)
```

Related: https://github.com/thefloweringash/tzsp2pcap/issues/4

[description]: https://web.archive.org/web/20050404125022/http://www.networkchemistry.com/support/appnotes/an001_tzsp.html